### PR TITLE
feat(stats): skip-round-record-POM-53

### DIFF
--- a/components/Timer/TimerContextProvider.tsx
+++ b/components/Timer/TimerContextProvider.tsx
@@ -3,6 +3,7 @@ import {
   getNextRound,
   getRoundType,
   getSecondsReset,
+  isTimerRoundSecondsType,
 } from './helpers/timerHelpers';
 import {
   scheduleNotification,
@@ -54,10 +55,13 @@ function TimerContextProvider({ children }: TimerContextProviderProps) {
   const [secondsLeft, setSecondsLeft] = useState(1500);
   const [appStateVisible, setAppStateVisible] = useState(true);
 
+  const [initialAdvanceRound, setInitialAdvanceRound] = useState(false);
+
   // When the timer status changes, this effect advances the round number.
   useEffect(() => {
     if (!timerActive) {
       advanceRound();
+      setInitialAdvanceRound(true);
     }
   }, [timerActive]);
 
@@ -118,6 +122,14 @@ function TimerContextProvider({ children }: TimerContextProviderProps) {
 
   // ----- TIMER CONTROL METHODS -----
   const advanceRound = () => {
+    if (initialAdvanceRound && isTimerRoundSecondsType(secondsLeft)) {
+      addRecord({
+        date: new Date().getTime(),
+        roundType: roundType,
+        completed: 0,
+      });
+    }
+
     const nextRound = getNextRound(roundNumber);
     const nextRoundType = getRoundType(nextRound);
     setRoundNumber(nextRound);

--- a/components/Timer/__tests__/timerHelpers.ts
+++ b/components/Timer/__tests__/timerHelpers.ts
@@ -13,6 +13,7 @@ import {
   getNextRoundSecondsDisplay,
   fmtMSS,
   getRoundLoadingText,
+  isTimerRoundSecondsType,
 } from '../helpers/timerHelpers';
 
 // getNextRound
@@ -143,5 +144,24 @@ describe('fmtMSS returns a seconds number formatted for alarm clock time', () =>
   });
   it("0 returns '0:00'", () => {
     expect(fmtMSS(0)).toBe('0:00');
+  });
+});
+
+// isTimerRoundSecondsType
+describe('isTimerRoundSecondsType returns the correct boolean value', () => {
+  it('returns true for work round', () => {
+    expect(isTimerRoundSecondsType(TimerRoundSeconds.Work)).toBe(true);
+  });
+  it('returns true for short break round', () => {
+    expect(isTimerRoundSecondsType(TimerRoundSeconds.ShortBreak)).toBe(true);
+  });
+  it('returns true for long break round', () => {
+    expect(isTimerRoundSecondsType(TimerRoundSeconds.LongBreak)).toBe(true);
+  });
+  it('returns false for invalid round', () => {
+    expect(isTimerRoundSecondsType(0)).toBe(false);
+  });
+  it('returns false for random number', () => {
+    expect(isTimerRoundSecondsType(356)).toBe(false);
   });
 });

--- a/components/Timer/helpers/timerHelpers.ts
+++ b/components/Timer/helpers/timerHelpers.ts
@@ -103,3 +103,9 @@ export const getRoundLoadingText = (roundNumber: number): TimerLoadingText => {
 export const fmtMSS = (s: number) => {
   return (s - (s %= 60)) / 60 + (9 < s ? ':' : ':0') + s;
 };
+
+export const isTimerRoundSecondsType = (
+  seconds: number
+): seconds is TimerRoundSeconds => {
+  return Object.values(TimerRoundSeconds).includes(seconds);
+};


### PR DESCRIPTION
Records are now created when a round is skipped. The `completed` property of the round's `RoundData` will be set to `0` indicating that the round was skipped, and this will give us the ability to use the concept of skipped rounds when presenting various types of stats to the user -- ie: how many total rounds they have skipped, and which type of rounds they are skipping.